### PR TITLE
Hide some files from git diff

### DIFF
--- a/scripts/fetch.js
+++ b/scripts/fetch.js
@@ -198,7 +198,7 @@ const update = async () => {
   console.log(gitStatus)
   if (gitStatus) {
     console.log(chalk.red('some files updated, please check and commit them'))
-    const { stdout: gitDiff } = await execAsync('git diff')
+    const { stdout: gitDiff } = await execAsync('git diff -- . ":!i18n/en-US.json" ":!package-lock.json"')
     console.log(prettifyDiff(gitDiff))
     //  auto commit the changes or notify error in CI
     if (process.env.CI) {


### PR DESCRIPTION
Files like `i18n/en-US.json` and `package-lock.json` are big and autogenerated, so maybe they should be hidden from `git diff` (still will be noted in `git status -s`). Big diffs can also cause an exception due to [`maxBuffer`](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback).